### PR TITLE
日報への言及機能（本文内にリンク記述とリンク元に引用されている（引用者の日報）ことを表示）の追加

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,7 +11,14 @@ class ReportsController < ApplicationController
     @report = Report.find(params[:id])
   end
 
-  # GET /reports/new
+  def show
+    if Report.exists?(id: params[:id])
+      @report = Report.find(params[:id])
+    else
+      redirect_to reports_path, alert: t('controllers.common.report_alert', name: Report.model_name.human)
+    end
+  end
+
   def new
     @report = current_user.reports.new
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,10 +8,6 @@ class ReportsController < ApplicationController
   end
 
   def show
-    @report = Report.find(params[:id])
-  end
-
-  def show
     if Report.exists?(id: params[:id])
       @report = Report.find(params[:id])
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,15 +19,24 @@ module ApplicationHelper
     safe_join(content.split("\n"), tag.br)
   end
 
-  def content_url_to_link(content)
+  def autolink_with_title(content)
     uri_reg = URI::DEFAULT_PARSER.make_regexp(%w[http https])
     content.gsub(uri_reg) do |url|
-      id = url.split('/').last.to_i
-      if id != 0 && Report.exists?(id:)
-        %(<a href='#{url}' target='_blank'>#{Report.find(id).title}</a>)
-      else
+      begin
+        uri_path = URI.parse(url).path.split('/')
+        case uri_path[1]
+        when 'books'
+          book = Book.where(id: uri_path[2]).select(:title).first
+          book ? %(<a href="#{url}" target="_blank">#{book.title}</a>) : url
+        when 'reports'
+          report = Report.where(id: uri_path[2]).select(:title).first
+          report ? %(<a href="#{url}" target="_blank">#{report.title}</a>) : url
+        else
+          url
+        end
+      rescue
         url
       end
-    end
+    end.html_safe
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
     safe_join(content.split("\n"), tag.br)
   end
 
-  def text_url_to_link(content)
+  def content_url_to_link(content)
     require 'uri'
     uri_reg = URI.regexp(%w[http https])
     content.gsub(uri_reg) { %{<a href='#{$&}' target='_blank'>#{$&}</a>} }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,6 @@ module ApplicationHelper
   end
 
   def content_url_to_link(content)
-    require 'uri'
     uri_reg = URI.regexp(%w[http https])
     content.gsub(uri_reg) { %{<a href='#{$&}' target='_blank'>#{$&}</a>} }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,13 @@ module ApplicationHelper
 
   def content_url_to_link(content)
     uri_reg = URI::DEFAULT_PARSER.make_regexp(%w[http https])
-    content.gsub(uri_reg) { %(<a href='#{::Regexp.last_match(0)}' target='_blank'>#{::Regexp.last_match(0)}</a>) }
+    content.gsub(uri_reg) do |url|
+      id = url.split('/').last.to_i
+      if id != 0 && Report.exists?(id:)
+        %(<a href='#{url}' target='_blank'>#{Report.find(id).title}</a>)
+      else
+        url
+      end
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,11 @@ module ApplicationHelper
   def format_content(content)
     safe_join(content.split("\n"), tag.br)
   end
+
+  def text_url_to_link(content)
+    require 'uri'
+    uri_reg = URI.regexp(%w[http https])
+    content.gsub(uri_reg) { %{<a href='#{$&}' target='_blank'>#{$&}</a>} }
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,8 +20,7 @@ module ApplicationHelper
   end
 
   def content_url_to_link(content)
-    uri_reg = URI.regexp(%w[http https])
-    content.gsub(uri_reg) { %{<a href='#{$&}' target='_blank'>#{$&}</a>} }
+    uri_reg = URI::DEFAULT_PARSER.make_regexp(%w[http https])
+    content.gsub(uri_reg) { %(<a href='#{::Regexp.last_match(0)}' target='_blank'>#{::Regexp.last_match(0)}</a>) }
   end
-
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -28,11 +28,9 @@ class Report < ApplicationRecord
   def create_mentioning_to
     mentioning_to.clear
     report_ids = content.scan(%r{(?<=http://localhost:3000/reports/)\d+}).uniq.map(&:to_i)
-    
+
     report_ids.each do |report_id|
-      if Report.exists?(id: report_id)
-        mentioning_to.create!(mentioned_report_id: report_id)
-      end
+      mentioning_to.create!(mentioned_report_id: report_id) if Report.exists?(id: report_id)
     end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -26,10 +26,10 @@ class Report < ApplicationRecord
   private
 
   def create_mentioning_to
-    self.mentioning_to.clear
-    report_ids = self.content.scan(%r{(?<=http://localhost:3000/reports/)\d+}).uniq.map(&:to_i)
+    mentioning_to.clear
+    report_ids = content.scan(%r{(?<=http://localhost:3000/reports/)\d+}).uniq.map(&:to_i)
     report_ids.each do |report_id|
-      self.mentioning_to.create!(mentioned_report_id: report_id)
+      mentioning_to.create!(mentioned_report_id: report_id)
     end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -13,6 +13,8 @@ class Report < ApplicationRecord
   has_many :mentioned_reports, through: :mentioned_from, source: :mentioning_report
   has_many :mentioning_reports, through: :mentioning_to, source: :mentioned_report
 
+  after_save :create_mentioning_to
+
   def editable?(target_user)
     user == target_user
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,14 +7,6 @@ class Report < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
 
-  has_many :mentioned_from, class_name: 'ReportReferenceRelationship', foreign_key: :mentioned_report_id, dependent: :destroy, inverse_of: 'mentioned_report'
-  has_many :mentioned_reports, through: :mentioned_from, source: :mentioning_report
-
-  has_many :mentioning_to, class_name: 'ReportReferenceRelationship', foreign_key: :mentioning_report_id, dependent: :destroy, inverse_of: 'mentioning_report'
-  has_many :mentioning_reports, through: :mentioning_to, source: :mentioned_report
-
-  after_save :create_mentioning_to
-
   def editable?(target_user)
     user == target_user
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -28,8 +28,11 @@ class Report < ApplicationRecord
   def create_mentioning_to
     mentioning_to.clear
     report_ids = content.scan(%r{(?<=http://localhost:3000/reports/)\d+}).uniq.map(&:to_i)
+    
     report_ids.each do |report_id|
-      mentioning_to.create!(mentioned_report_id: report_id)
+      if Report.exists?(id: report_id)
+        mentioning_to.create!(mentioned_report_id: report_id)
+      end
     end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,6 +7,14 @@ class Report < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
 
+  has_many :mentioned_from, class_name: 'ReportReferenceRelationship', foreign_key: :mentioned_report_id, dependent: :destroy, inverse_of: 'mentioned_report'
+  has_many :mentioned_reports, through: :mentioned_from, source: :mentioning_report
+
+  has_many :mentioning_to, class_name: 'ReportReferenceRelationship', foreign_key: :mentioning_report_id, dependent: :destroy, inverse_of: 'mentioning_report'
+  has_many :mentioning_reports, through: :mentioning_to, source: :mentioned_report
+
+  after_save :create_mentioning_to
+
   def editable?(target_user)
     user == target_user
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,11 +7,27 @@ class Report < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
 
+  has_many :mentioned_from, class_name: 'ReportReferenceRelationship', foreign_key: :mentioned_report_id, dependent: :destroy, inverse_of: 'mentioned_report'
+  has_many :mentioning_to, class_name: 'ReportReferenceRelationship', foreign_key: :mentioning_report_id, dependent: :destroy, inverse_of: 'mentioning_report'
+
+  has_many :mentioned_reports, through: :mentioned_from, source: :mentioning_report
+  has_many :mentioning_reports, through: :mentioning_to, source: :mentioned_report
+
   def editable?(target_user)
     user == target_user
   end
 
   def created_on
     created_at.to_date
+  end
+
+  private
+
+  def create_mentioning_to
+    self.mentioning_to.clear
+    report_ids = self.content.scan(%r{(?<=http://localhost:3000/reports/)\d+}).uniq.map(&:to_i)
+    report_ids.each do |report_id|
+      self.mentioning_to.create!(mentioned_report_id: report_id)
+    end
   end
 end

--- a/app/models/report_reference_relationship.rb
+++ b/app/models/report_reference_relationship.rb
@@ -1,0 +1,2 @@
+class ReportReferenceRelationship < ApplicationRecord
+end

--- a/app/models/report_reference_relationship.rb
+++ b/app/models/report_reference_relationship.rb
@@ -1,5 +1,3 @@
 class ReportReferenceRelationship < ApplicationRecord
-  belongs_to :mentioning_report, class_name: 'Report'
-  belongs_to :mentioned_report, class_name: 'Report'
-  validates :mentioned_report_id, uniqueness: { scope: :mentioning_report_id }
+  
 end

--- a/app/models/report_reference_relationship.rb
+++ b/app/models/report_reference_relationship.rb
@@ -3,4 +3,5 @@
 class ReportReferenceRelationship < ApplicationRecord
   belongs_to :mentioning_report, class_name: 'Report'
   belongs_to :mentioned_report, class_name: 'Report'
+  validates :mentioned_report_id, uniqueness: { scope: :mentioning_report_id }
 end

--- a/app/models/report_reference_relationship.rb
+++ b/app/models/report_reference_relationship.rb
@@ -1,2 +1,5 @@
 class ReportReferenceRelationship < ApplicationRecord
+  belongs_to :mentioning_report, class_name: 'Report'
+  belongs_to :mentioned_report, class_name: 'Report'
+  validates :mentioned_report_id, uniqueness: { scope: :mentioning_report_id }
 end

--- a/app/models/report_reference_relationship.rb
+++ b/app/models/report_reference_relationship.rb
@@ -1,3 +1,4 @@
 class ReportReferenceRelationship < ApplicationRecord
-  
+  belongs_to :mentioning_report, class_name: 'Report'
+  belongs_to :mentioned_report, class_name: 'Report'
 end

--- a/app/models/report_reference_relationship.rb
+++ b/app/models/report_reference_relationship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReportReferenceRelationship < ApplicationRecord
   belongs_to :mentioning_report, class_name: 'Report'
   belongs_to :mentioned_report, class_name: 'Report'

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -6,7 +6,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:content) %>:</strong>
-    <%= content_url_to_link(h(report.content)).html_safe %>
+    <%= content_url_to_link(h(format_content(report.content))).html_safe %>
   </p>
 
   <p>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -6,7 +6,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:content) %>:</strong>
-    <%= format_content content_url_to_link report.content %>
+    <%= content_url_to_link(h(report.content)).html_safe %>
   </p>
 
   <p>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -19,13 +19,4 @@
     <%= l report.created_on %>
   </p>
 
-  <p>
-    <strong><%= t('views.reports.mentioned_from') %>:</strong>
-  </p>
-  <ul>
-    <% report.mentioned_reports.each do |report| %>
-      <li><%= link_to report.title, report %></li>
-    <% end %>
-  </ul>
-
 </div>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -6,7 +6,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:content) %>:</strong>
-    <%= format_content text_url_to_link report.content %>
+    <%= format_content content_url_to_link report.content %>
   </p>
 
   <p>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -19,4 +19,13 @@
     <%= l report.created_on %>
   </p>
 
+  <p>
+    <strong><%= t('views.reports.mentioned_from') %>:</strong>
+  </p>
+  <ul>
+    <% report.mentioned_reports.each do |report| %>
+      <li><%= link_to report.title, report %></li>
+    <% end %>
+  </ul>
+
 </div>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -6,7 +6,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:content) %>:</strong>
-    <%= content_url_to_link(h(format_content(report.content))).html_safe %>
+    <%= autolink_with_title(h(format_content(report.content))).html_safe %>
   </p>
 
   <p>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -6,7 +6,7 @@
 
   <p>
     <strong><%= Report.human_attribute_name(:content) %>:</strong>
-    <%= format_content report.content %>
+    <%= format_content text_url_to_link report.content %>
   </p>
 
   <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,7 @@ en:
       notice_create: "%{name} was successfully created."
       notice_update: "%{name} was successfully updated."
       notice_destroy: "%{name} was successfully destroyed."
+      report_alert: "%{name} does not exist."
   layouts:
     menu:
       menu: Menu

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -196,6 +196,8 @@ ja:
       validation_error: "%{errors}があるため、この%{name}は保存できませんでした"
       title_show: "%{name}の詳細"
       sign_out: ログアウト
+    reports:
+      mentioned_from: この日報は以下の日報から言及されています
     pagination:
       first: '« 最初'
       last: '最後 »'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -209,6 +209,7 @@ ja:
       notice_create: "%{name}が作成されました。"
       notice_update: "%{name}が更新されました。"
       notice_destroy: "%{name}が削除されました。"
+      report_alert: "%{name}が存在しません。"
   layouts:
     menu:
       menu: メニュー

--- a/db/migrate/20230314062007_create_report_reference_relationships.rb
+++ b/db/migrate/20230314062007_create_report_reference_relationships.rb
@@ -1,0 +1,8 @@
+class CreateReportReferenceRelationships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :report_reference_relationships do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230314062007_create_report_reference_relationships.rb
+++ b/db/migrate/20230314062007_create_report_reference_relationships.rb
@@ -1,7 +1,9 @@
 class CreateReportReferenceRelationships < ActiveRecord::Migration[7.0]
   def change
     create_table :report_reference_relationships do |t|
-
+      t.integer :mentioning_report_id
+      t.integer :mentioned_report_id
+      
       t.timestamps
     end
   end

--- a/db/migrate/20230314080404_add_index_to_report_reference_relationships.rb
+++ b/db/migrate/20230314080404_add_index_to_report_reference_relationships.rb
@@ -1,0 +1,5 @@
+class AddIndexToReportReferenceRelationships < ActiveRecord::Migration[7.0]
+  def change
+    add_index :report_mention_relationships, [:mentioned_report_id, :mentioning_report_id], unique: true, name: 'report_mention_relationship_index'
+  end
+end

--- a/db/migrate/20230314080404_add_index_to_report_reference_relationships.rb
+++ b/db/migrate/20230314080404_add_index_to_report_reference_relationships.rb
@@ -1,5 +1,5 @@
 class AddIndexToReportReferenceRelationships < ActiveRecord::Migration[7.0]
   def change
-    add_index :report_mention_relationships, [:mentioned_report_id, :mentioning_report_id], unique: true, name: 'report_mention_relationship_index'
+    add_index :report_reference_relationships, [:mentioned_report_id, :mentioning_report_id], unique: true, name: 'report_reference_relationships_index'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_14_062007) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_080404) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_062007) do
     t.integer "mentioned_report_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["mentioned_report_id", "mentioning_report_id"], name: "report_reference_relationships_index", unique: true
   end
 
   create_table "reports", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_062007) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -57,6 +57,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
     t.datetime "updated_at", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "report_reference_relationships", force: :cascade do |t|
+    t.integer "mentioning_report_id"
+    t.integer "mentioned_report_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "reports", force: :cascade do |t|

--- a/test/fixtures/report_reference_relationships.yml
+++ b/test/fixtures/report_reference_relationships.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/report_reference_relationship_test.rb
+++ b/test/models/report_reference_relationship_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReportReferenceRelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/report_reference_relationship_test.rb
+++ b/test/models/report_reference_relationship_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ReportReferenceRelationshipTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
## 学習の習い
- 多対多のモデルの関連付けを学ぶ
- 少し応用的な関連付けの方法を学ぶ
- scaffoldとはちょっと異なる、応用的なデータ保存の方法を学ぶ
## 終了条件
- Railsアプリに日報の言及機能を追加する
### 必須要件
- Aさんの日報の本文テキストにBさんの日報のURL（ http://localhost:3000/reports/44 など）が含まれていると、Bさんの日報に「この日報に言及している日報」としてAさんの日報が表示される
  - Qiitaの「この記事は以下の記事からリンクされています」と同じようなイメージです（[Qiitaの例](https://qiita.com/jnchito/items/893c887fbf19e17d3ff9)）
- 検知すべきドメイン（host）は http://localhost:3000/ だけでOKです
- 日報の新規作成時だけでなく更新時や削除時も言及が更新される
  - （本文テキストから日報のURLがなくなったら言及もなくなる）
- 実装した機能の動きがわかるスクショを載せる
- rubocopとerblintをパスさせる（要スクリーンショット）